### PR TITLE
Limit edit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,7 @@ before_script:
 script:
   - nimble install -y
   - python3 bin/runtests.py
+cache:
+  directories:
+    - nim-devel
+    - nimble

--- a/reactor/async/asyncutil.nim
+++ b/reactor/async/asyncutil.nim
@@ -100,7 +100,7 @@ proc forEach*[T](self: Stream[T], function: (proc(x: T))): Future[void] {.async.
 proc pipeLimited*[T](self: Stream[T], provider: Provider[T], limit: int64): Future[void] {.async.} =
   var limit = limit
   while limit > 0:
-    let data = await self.receiveSome(max(limit, (baseBufferSizeFor(T) * 8).int64).int)
+    let data = await self.receiveSome(limit.int)
     limit -= data.len
     await provider.provideAll(data)
   provider.sendClose(JustClose)

--- a/reactor/http/httpclient.nim
+++ b/reactor/http/httpclient.nim
@@ -132,7 +132,7 @@ proc readResponse*(conn: HttpConnection, expectingBody=true): Future[HttpRespons
   if not expectingBody:
     return response
 
-  let te = response.headers.getOrDefault("tranfer-encoding", "")
+  let te = response.headers.getOrDefault("transfer-encoding", "")
   if te == "chunked":
     response.dataStream = conn.readChunked()
   elif te == "":

--- a/reactor/http/httpcommon.nim
+++ b/reactor/http/httpcommon.nim
@@ -113,7 +113,7 @@ proc reverse(s: var string) =
     swap(s[i], s[s.len - 1 - i])
 
 proc tryParseHexUint64*(val: string): Result[int64] =
-  var val = val
+  var val = val.strip
   if val.len > 15:
     return error(int64, "integer too large")
 
@@ -131,7 +131,7 @@ proc tryParseHexUint64*(val: string): Result[int64] =
   return just(res)
 
 proc tryParseUint64*(val: string): Result[int64] =
-  var val = val
+  var val = val.strip
   if val.len > 19:
     return error(int64, "integer too large")
 


### PR DESCRIPTION
Deleted max select in pipeLimited proc because of it's incorrect logic.
proc pipeLimited was used only in httpclient.nim. It is used when length of body is known. That's why it has to read only certain number of digits and not more
